### PR TITLE
Fixed Typing error: `Could not find a declaration file for module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
+    "default": ["./dist/index.mjs", "./dist/index.js"],
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-rewrite-all",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Merging this PR resolves the following issue:
![image](https://github.com/ivesia/vite-plugin-rewrite-all/assets/26258709/144ec042-9294-40b2-92b7-bdb866f8f849)

This is done via adding the `default` block to the `exports` statement.

Screenshot that it still works:
![image](https://github.com/ivesia/vite-plugin-rewrite-all/assets/26258709/11262800-48ca-47cc-acb1-3a9d63bcdfaa)
