### PR TITLE
re-order exports object in package.json per spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
-    "default": ["./dist/index.mjs", "./dist/index.js"],
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "default": ["./dist/index.mjs", "./dist/index.js"]
   },
   "license": "MIT",
   "author": "AlphaTr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-rewrite-all",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Recent PR #2 by @CommanderStorm broke our build (and @ericleponner 's - see #7).

Looking at PR #2 and comparing it to the spec (https://nodejs.org/api/packages.html#conditional-exports) shows me that the ordering of the object is not correct.

Specifically this part:

> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. **This condition should always come last**

This PR aims to fix this. Confirmed to fix on our end.